### PR TITLE
Added the special thanks for the desktop icon in the release note default template.

### DIFF
--- a/.github/workflows/build-rpm.yml
+++ b/.github/workflows/build-rpm.yml
@@ -153,6 +153,12 @@ jobs:
             :white_check_mark: Highlights
             - (fill me in)
             
+            ❤️ Special Thanks
+
+            - Major thanks for the icon design to **Cristian Slavik** from **NOX Visual Effects**
+              - GitHub: https://github.com/crisslavik
+              - LinkedIn: https://www.linkedin.com/in/crisslavik/
+
             :package: Assets
             - EL9 RPM
             - EL10 RPM (experimental)


### PR DESCRIPTION
## Summary

This PR updates the GitHub release-note template in `.github/workflows/build-rpm.yml` to properly include the __Special Thanks__ section.

## What changed

- Kept the existing credit to __Cristian Slavik (NOX Visual Effects)__.
- Fixed markdown/indentation so the section renders correctly in release notes.
- Simplified GitHub and LinkedIn links to clean URL format.

## Why

The previous formatting could render inconsistently in GitHub Releases. This change ensures the acknowledgement appears cleanly and reliably in every generated release body.
