### PR TITLE
Fixing polkit to prompt once the app is open until closed.

### DIFF
--- a/src/org.almalinux.creativeinstaller.policy
+++ b/src/org.almalinux.creativeinstaller.policy
@@ -12,7 +12,7 @@
       <allow_inactive>no</allow_inactive>
       <allow_active>auth_admin_keep</allow_active>
     </defaults>
-    <annotate key="org.freedesktop.policykit.exec.path">/usr/libexec/alma-creative-installer-helper</annotate>
+    <annotate key="org.freedesktop.policykit.exec.path">/usr/libexec/almalinux-creative-installer-helper</annotate>
     <annotate key="org.freedesktop.policykit.exec.allow_gui">true</annotate>
   </action>
 </policyconfig>


### PR DESCRIPTION
## Summary

Fix polkit action-to-helper path mismatch so pkexec correctly maps to the intended policy action (`org.almalinux.creativeinstaller`) and restores expected authentication caching behavior (`auth_admin_keep`).

## Related Issue

N/A (polkit auth prompt regression investigation)

## Why this change?

The policy file referenced `/usr/libexec/alma-creative-installer-helper` while the app/spec use `/usr/libexec/almalinux-creative-installer-helper`. Because of this mismatch, pkexec may not use the intended custom action, causing repeated password prompts instead of keep-auth behavior during a session.

## Type of change

- 🐛 Bug fix
- ✨ New feature
- 🎨 UI/UX improvement
- 📝 Documentation update
- 🧹 Refactor / cleanup
- 🧹 GitHub Action Change

## What was done ? :

- Updated `src/org.almalinux.creativeinstaller.policy`

  - `org.freedesktop.policykit.exec.path`:

    - from: `/usr/libexec/alma-creative-installer-helper`
    - to: `/usr/libexec/almalinux-creative-installer-helper`

- Verified path consistency with:

  - app helper constant (`src/almalinux-creative-installer`)
  - RPM spec install target (`src/packaging/almalinux-creative-installer.spec`)

## Beta RPM / Release Draft checks

- I confirmed this PR generated beta RPM artifacts in Actions (`rpm-el9-pr<PR#>` and `rpm-el10-pr<PR#>`)
- I validated the sticky PR comment includes the beta RPM artifacts link
- If this change impacts release flow, I confirmed tag builds create a __Draft__ GitHub Release

## Testing Done

- Verified on AlmaLinux Version: ______
- Verified Desktop Environment (if applicable): ______
- Successfully completed a test installation run
- Verified logs for any new errors

## Screenshots (if UI changed)

N/A (no UI change)

## Checklist

- I've read `CONTRIBUTING.md`
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I've confirmed this PR follows the Code of Conduct
