### PR TITLE
Added a search bar in addition to the categories for ease of search since we are starting to get more and more apps.

### DIFF
--- a/src/almalinux-creative-installer
+++ b/src/almalinux-creative-installer
@@ -590,14 +590,8 @@ class AlmaCreativeInstaller(Gtk.Window):
         if not self.search_query:
             return True
 
-        haystack = " ".join(
-            [
-                app.get("name", ""),
-                app.get("id", ""),
-                app.get("category", ""),
-                self._subtitle_for_app(app),
-            ]
-        ).lower()
+        # Name-only filtering by request (do not match id/category/subtitle).
+        haystack = app.get("name", "").lower()
         return self.search_query in haystack
 
     def _apply_filters(self):


### PR DESCRIPTION
## Summary

Add a small search bar to the Apps tab so users can quickly find software entries by name.

## Related Issue

User request to make it easier to find apps in larger lists.

## Why this change?

As the app catalog grows, scrolling through categories can be slower for users. A simple search input improves discoverability and speed, especially for beginners who may only remember part of an app name.

## Type of change

- 🐛 Bug fix
- ✨ New feature
- 🎨 UI/UX improvement
- 📝 Documentation update
- 🧹 Refactor / cleanup
- 🧹 GitHub Action Change

## What was done ? :

- Added a `Gtk.SearchEntry` above the app list in the Apps tab.

- Added search state tracking (`self.search_query`).

- Implemented `on_search_changed()` callback to update filtering live as the user types.

- Refactored list filtering into combined logic:
  - category filter + search filter (AND behavior)

- Search is case-insensitive and matches against:

  - app name
  - app id
  - app category
  - app subtitle text

- Existing category sidebar behavior remains unchanged.

## Beta RPM / Release Draft checks

- I confirmed this PR generated beta RPM artifacts in Actions (`rpm-el9-pr<PR#>` and `rpm-el10-pr<PR#>`)
- I validated the sticky PR comment includes the beta RPM artifacts link
- If this change impacts release flow, I confirmed tag builds create a __Draft__ GitHub Release

## Testing Done

- Verified on AlmaLinux Version: ______
- Verified Desktop Environment (if applicable): ______
- Successfully completed a test installation run
- Verified logs for any new errors

## Screenshots (if UI changed)

- Add screenshot of Apps tab showing new `Search apps:` field and filtered results while typing.

## Checklist

- I've read `CONTRIBUTING.md`
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I've confirmed this PR follows the Code of Conduct
