### PR TITLE
feat: add 3DCoat as guided tarball install (ZBrush alternative)

### DIFF
--- a/src/almalinux-creative-installer
+++ b/src/almalinux-creative-installer
@@ -17,6 +17,7 @@ from collections import deque
 
 HELPER = "/usr/libexec/almalinux-creative-installer-helper"
 RESOLVE_URL = "https://www.blackmagicdesign.com/products/davinciresolve/"
+THREEDC_URL = "https://3dcoat.com/#auth"
 APPIMAGELAUNCHER_VERSION = "3.0.0-beta-2-gha287.96cb937"
 APPIMAGELAUNCHER_RPM_URL = (
     "https://github.com/TheAssassin/AppImageLauncher/releases/download/"
@@ -163,6 +164,13 @@ APPS = [
         "type": "flatpak",
         "appid": "org.freecad.FreeCAD",
         "emoji": "📐",
+        "category": "3D",
+    },
+    {
+        "id": "3dcoat",
+        "name": "3DCoat",
+        "type": "3dcoat",
+        "emoji": "🗿",
         "category": "3D",
     },
     {
@@ -779,6 +787,9 @@ class AlmaCreativeInstaller(Gtk.Window):
         elif app["type"] == "resolve":
             install_btn.connect("clicked", lambda *_: self.install_resolve_flow())
             remove_btn.connect("clicked", lambda *_: self.remove_resolve_flow())
+        elif app["type"] == "3dcoat":
+            install_btn.connect("clicked", lambda *_: self.install_3dcoat_flow())
+            remove_btn.connect("clicked", lambda *_: self.remove_3dcoat_flow())
 
         self.app_widgets[app["id"]] = {
             "app": app,
@@ -848,6 +859,8 @@ class AlmaCreativeInstaller(Gtk.Window):
             return "Installed via Flatpak (recommended upstream for EL)"
         if app["type"] == "resolve":
             return "Guided install: deps → open download page → pick .run/.rpm"
+        if app["type"] == "3dcoat":
+            return "Guided install: log in → download Linux tarball → pick .tar archive"
         return ""
 
     # ---------------- Busy UI helpers ----------------
@@ -1409,6 +1422,18 @@ class AlmaCreativeInstaller(Gtk.Window):
 
         if app["type"] == "resolve":
             installed = self._resolve_installed()
+            if installed:
+                w["status"].set_text("✅ Installed")
+                w["install"].set_sensitive(False)
+                w["remove"].set_sensitive(True)
+            else:
+                w["status"].set_text("ℹ️ Guided install")
+                w["install"].set_sensitive(True)
+                w["remove"].set_sensitive(False)
+            return
+
+        if app["type"] == "3dcoat":
+            installed = self._3dcoat_installed()
             if installed:
                 w["status"].set_text("✅ Installed")
                 w["install"].set_sensitive(False)
@@ -1999,6 +2024,96 @@ class AlmaCreativeInstaller(Gtk.Window):
                 GLib.idle_add(self.set_app_busy, "resolve", False)
 
         threading.Thread(target=worker, daemon=True).start()
+
+
+    # ---------------- 3DCoat flow ----------------
+    def _3dcoat_installed(self):
+        if Path("/usr/bin/3dcoat").exists():
+            return True
+        opt_dir = Path("/opt/3DCoat")
+        if opt_dir.is_dir() and any(opt_dir.iterdir()):
+            return True
+        return shutil.which("3dcoat") is not None
+
+    def install_3dcoat_flow(self):
+        self.set_app_busy("3dcoat", True, "Waiting for file…")
+        self._set_app_progress_fraction("3dcoat", 0.02)
+
+        if shutil.which("xdg-open"):
+            subprocess.Popen(["xdg-open", THREEDC_URL])
+            self.append_log("Opened 3DCoat download page.\n")
+
+        self.append_log(
+            "Log in, download the Linux tarball, then select it below to continue.\n"
+        )
+        self.pick_3dcoat_installer()
+
+    def pick_3dcoat_installer(self):
+        dialog = Gtk.FileChooserDialog(
+            title="Select 3DCoat Linux tarball",
+            parent=self,
+            action=Gtk.FileChooserAction.OPEN,
+        )
+        dialog.add_buttons(
+            Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL,
+            Gtk.STOCK_OPEN, Gtk.ResponseType.OK,
+        )
+
+        f = Gtk.FileFilter()
+        f.set_name("Tarballs (*.tar, *.tar.bz2, *.tar.gz, *.tar.xz, *.tar.zst)")
+        for pat in ("*.tar", "*.tar.bz2", "*.tar.gz", "*.tar.xz", "*.tar.zst", "*.tgz"):
+            f.add_pattern(pat)
+        dialog.add_filter(f)
+
+        resp = dialog.run()
+        if resp == Gtk.ResponseType.OK:
+            path = dialog.get_filename()
+            if path:
+                self._set_app_progress_fraction("3dcoat", 0.05)
+                self.run_helper_with_callback(
+                    ["install_3dcoat", path],
+                    on_success=lambda: self._finish_app_action("3dcoat"),
+                    app_id="3dcoat",
+                    progress_segment=(0.05, 0.98),
+                )
+            else:
+                self.set_app_busy("3dcoat", False)
+        else:
+            self.set_app_busy("3dcoat", False)
+        dialog.destroy()
+
+    def remove_3dcoat_flow(self):
+        if not self._3dcoat_installed():
+            self.append_log("ℹ️ 3DCoat does not appear to be installed.\n")
+            self.refresh_app_state("3dcoat")
+            return
+
+        dialog = Gtk.MessageDialog(
+            parent=self,
+            flags=0,
+            message_type=Gtk.MessageType.WARNING,
+            buttons=Gtk.ButtonsType.NONE,
+            text="Uninstall 3DCoat?",
+        )
+        dialog.format_secondary_text(
+            "This will remove /opt/3DCoat, the /usr/bin/3dcoat symlink, "
+            "and the desktop entry."
+        )
+        dialog.add_button("Cancel", Gtk.ResponseType.CANCEL)
+        dialog.add_button("Uninstall", Gtk.ResponseType.OK)
+
+        resp = dialog.run()
+        dialog.destroy()
+
+        if resp == Gtk.ResponseType.OK:
+            self.set_app_busy("3dcoat", True, "Removing…")
+            self._set_app_progress_fraction("3dcoat", 0.02)
+            self.run_helper_with_callback(
+                ["remove_3dcoat"],
+                on_success=lambda: self._finish_app_action("3dcoat"),
+                app_id="3dcoat",
+                progress_segment=(0.02, 0.98),
+            )
 
 
 def main():

--- a/src/almalinux-creative-installer-helper
+++ b/src/almalinux-creative-installer-helper
@@ -406,6 +406,138 @@ install_local_file() {
 }
 
 # -------------------------------------------------
+# 3DCoat
+# -------------------------------------------------
+install_3dcoat() {
+  local tar_path="${1:-}"
+  local install_base="/opt/3DCoat"
+
+  [[ -n "${tar_path}" ]] || { echo "ERROR: missing tarball path" >&2; exit 2; }
+  [[ -f "${tar_path}" ]] || { echo "ERROR: tarball not found: ${tar_path}" >&2; exit 2; }
+
+  local user home
+  user="$(require_invoking_user)"
+  home="$(require_invoking_user_home)"
+
+  # Derive install dir from tarball filename (e.g. 3DCoat-2025.12.tar.bz2 -> 3DCoat-2025)
+  local file_name soft soft_dir
+  file_name="$(basename "${tar_path}")"
+  soft="${file_name%%.*}"
+  soft_dir="${install_base}/${soft}"
+
+  log "Creating installation directory ${soft_dir}..."
+  mkdir -p "${soft_dir}"
+
+  log "Extracting archive (this may take several minutes)..."
+  tar -xf "${tar_path}" -C "${soft_dir}" --strip-components=1
+  log "Extraction complete."
+
+  # Find the main executable (-print -quit avoids SIGPIPE with pipefail)
+  local exe exe_name
+  exe="$(find "${soft_dir}" -maxdepth 1 -type f -iname '3dcoat' -print -quit 2>/dev/null)"
+  if [[ -z "${exe}" ]]; then
+    exe="$(find "${soft_dir}" -maxdepth 1 -type f -iname '3dcoat*' -print -quit 2>/dev/null)"
+  fi
+  if [[ -z "${exe}" ]]; then
+    echo "ERROR: 3DCoat executable not found in ${soft_dir}" >&2
+    exit 1
+  fi
+  exe_name="$(basename "${exe}")"
+  chmod +x "${exe}"
+  log "Executable: ${exe}"
+
+  # Create launcher shell script using the actual detected exe name
+  local sh_path="${install_base}/3dcoat.sh"
+  printf '#!/bin/bash\ncd "%s" && ./%s "$@"\n' "${soft_dir}" "${exe_name}" > "${sh_path}"
+  chmod +x "${sh_path}"
+  chown "${user}:${user}" "${sh_path}"
+
+  # Symlink to /usr/bin
+  [[ -L /usr/bin/3dcoat ]] && unlink /usr/bin/3dcoat || true
+  ln -s "${sh_path}" /usr/bin/3dcoat
+  log "Created /usr/bin/3dcoat -> ${sh_path}"
+
+  # Desktop entry
+  local icon_path="${soft_dir}/data/Icon/3DCoat.png"
+  [[ -f "${icon_path}" ]] || icon_path="${sh_path}"
+
+  local desktop_dir="${home}/.local/share/applications"
+  mkdir -p "${desktop_dir}"
+  chown "${user}:${user}" "${desktop_dir}"
+
+  cat > "${desktop_dir}/3DCoat.desktop" <<EOF
+[Desktop Entry]
+Comment=3D modeling and sculpting software
+Encoding=UTF-8
+Version=1.0
+Type=Application
+Terminal=false
+Exec=${sh_path}
+Name=3DCoat
+Icon=${icon_path}
+Categories=Graphics;3DGraphics;
+StartupWMClass=3dcoat
+EOF
+  chown "${user}:${user}" "${desktop_dir}/3DCoat.desktop"
+  log "Desktop entry created."
+
+  # Fix PNG color profiles (best-effort — suppresses rendering warnings)
+  log "Installing ImageMagick for PNG profile normalization..."
+  dnf -y install ImageMagick || true
+  if command -v mogrify >/dev/null 2>&1; then
+    local png_files=()
+    while IFS= read -r f; do
+      png_files+=("${f}")
+    done < <(find "${soft_dir}" -type f -name '*.png' 2>/dev/null)
+    local total="${#png_files[@]}"
+    if (( total > 0 )); then
+      log "Fixing PNG color profiles: ${total} files found..."
+      local i=0
+      for f in "${png_files[@]}"; do
+        mogrify "${f}" 2>/dev/null || true
+        i=$(( i + 1 ))
+        if (( i % 100 == 0 || i == total )); then
+          log "PNG fix: ${i}/${total} ($(( i * 100 / total ))%)"
+        fi
+      done
+      log "PNG profile fix complete."
+    else
+      log "No PNG files found; skipping PNG color profile fix."
+    fi
+  else
+    log "mogrify not available; skipping PNG color profile fix."
+  fi
+
+  log "3DCoat installation complete."
+}
+
+remove_3dcoat() {
+  local user home
+  user="$(require_invoking_user)"
+  home="$(require_invoking_user_home)"
+
+  log "Removing 3DCoat..."
+
+  if [[ -L /usr/bin/3dcoat ]]; then
+    unlink /usr/bin/3dcoat
+    log "Removed /usr/bin/3dcoat symlink."
+  fi
+
+  if [[ -d /opt/3DCoat ]]; then
+    rm -rf /opt/3DCoat
+    log "Removed /opt/3DCoat."
+  fi
+
+  local desktop="${home}/.local/share/applications/3DCoat.desktop"
+  if [[ -f "${desktop}" ]]; then
+    rm -f "${desktop}"
+    log "Removed desktop entry."
+  fi
+
+  log "3DCoat removed."
+}
+
+# -------------------------------------------------
 # Dispatcher
 # -------------------------------------------------
 case "${action}" in
@@ -436,6 +568,10 @@ case "${action}" in
   resolve_post_install_fixes) resolve_post_install_fixes;;
   set_selinux_mode)      set_selinux_mode "${2:-}";;
   install_local_file)    install_local_file "${2:-}";;
+
+  # 3DCoat
+  install_3dcoat)        install_3dcoat "${2:-}";;
+  remove_3dcoat)         remove_3dcoat;;
 
   *)
     cat >&2 <<'EOF'
@@ -468,6 +604,10 @@ Local installers:
   resolve_post_install_fixes
   set_selinux_mode <permissive-temp|permissive|disabled|enforcing>
   install_local_file <path_to_.rpm_or_.run>
+
+3DCoat:
+  install_3dcoat <path_to_tarball>
+  remove_3dcoat
 EOF
     exit 1
     ;;


### PR DESCRIPTION
## Summary

- Adds **3DCoat** to the 3D category with a guided install flow modelled after DaVinci Resolve: opens `https://3dcoat.com/#auth` for the user to log in and download, then prompts them to select the Linux tarball
- Privileged helper handles: tarball extraction → executable detection → launcher script → `/usr/bin/3dcoat` symlink → `.desktop` entry → PNG color-profile normalization (ImageMagick, best-effort)
- Remove flow cleans up `/opt/3DCoat`, the symlink, and the desktop entry

## Improvements over the contributed script

| Issue | Fix |
|---|---|
| `$USER` env var (unreliable under sudo) | Uses `PKEXEC_UID` via `require_invoking_user()` |
| Launcher hardcoded `./3dcoat` | Uses actual detected executable name so `3DCoat` (capital) works |
| `find \| head -1` causes SIGPIPE under `set -o pipefail` | Uses `find -print -quit` |
| PNG mogrify silent for 10–15 min | Per-file loop with progress log every 100 files |
| `Terminal=true` in desktop entry | Fixed to `Terminal=false` |
| Inconsistent whitespace in desktop file | Clean heredoc |

## Test plan

- [ ] App appears in the 3D category
- [ ] Clicking Install opens `https://3dcoat.com/#auth` in browser and shows file picker
- [ ] Cancelling the file picker resets the busy state cleanly
- [ ] Selecting a valid 3DCoat tarball runs the helper and installs correctly
- [ ] `/usr/bin/3dcoat`, `/opt/3DCoat/<version>/`, and `~/.local/share/applications/3DCoat.desktop` are created
- [ ] Status shows ✅ Installed after success
- [ ] Remove flow shows confirmation dialog and cleans up all three locations
- [ ] Selecting a tarball where the binary is named `3DCoat` (capital) launches correctly